### PR TITLE
Add VRM viewer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ my_flutter_app/
 - 自适应亮度
 - 现代化的UI组件
 
+## VRM集成说明
+
+项目已集成 `flutter_unity_widget`，可以在应用中展示VRM模型。点击应用栏右侧的
+"VRM 演示"图标即可打开示例页面。要正确显示VRM模型，需要：
+
+1. 在Unity中创建支持VRM的场景并导出到Flutter项目中。
+2. 在`VRMViewerPage`中加载对应的Unity场景。
+
+Unity项目的配置和VRM模型文件请根据实际需求添加。
+
 ## 未来改进
 
 - [ ] 数据持久化存储

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'vrm_viewer_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -68,6 +69,19 @@ class _TodoListPageState extends State<TodoListPage> {
         title: const Text('我的待办事项'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         elevation: 2,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.threed_rotation),
+            tooltip: 'VRM 演示',
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const VRMViewerPage(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Column(
         children: [

--- a/lib/vrm_viewer_page.dart
+++ b/lib/vrm_viewer_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_unity_widget/flutter_unity_widget.dart';
+
+/// 一个简单的VRM模型查看页面，使用Unity来渲染模型。
+class VRMViewerPage extends StatefulWidget {
+  const VRMViewerPage({super.key});
+
+  @override
+  State<VRMViewerPage> createState() => _VRMViewerPageState();
+}
+
+class _VRMViewerPageState extends State<VRMViewerPage> {
+  UnityWidgetController? _controller;
+
+  void _onUnityCreated(UnityWidgetController controller) {
+    _controller = controller;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('VRM模型演示')),
+      body: UnityWidget(
+        onUnityCreated: _onUnityCreated,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  # Unity集成，用于展示VRM模型
+  flutter_unity_widget: ^2022.1.0
+
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- integrate `flutter_unity_widget` for showing VRM models
- create `VRMViewerPage` with a Unity widget
- add icon button in the app bar to open the VRM page
- document VRM integration in README

## Testing
- `flutter test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687beebba064832da740e0a1b4f409a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new page for VRM model demonstration, accessible via an icon in the app bar.
  * Integrated Unity rendering for VRM models within the Flutter app.

* **Documentation**
  * Updated the README with a section explaining VRM integration steps and usage.

* **Chores**
  * Added the `flutter_unity_widget` package as a new dependency for Unity integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->